### PR TITLE
option added to write dump in specific directory

### DIFF
--- a/R/tryCatchLog.R
+++ b/R/tryCatchLog.R
@@ -34,6 +34,7 @@
 #'                              (no filtering, wrapping or changing of semantics).
 #' @param finally               expression to be evaluated at the end
 #' @param write.error.dump.file \code{TRUE}: Saves a dump of the workspace and the call stack named \code{dump_<YYYYMMDD_HHMMSS>.rda}
+#' @param write.error.dump.folder    \code{path}: Saves the dump of the workspace in a specific folder instead of the working directory
 #' @param silent.warnings       \code{TRUE}: Warnings are logged, but not propagated to the caller.\cr
 #'                              \code{FALSE}: Warnings are logged and treated according to the global
 #'                              setting in \code{\link{getOption}("warn")}. See also \code{\link{warning}}.
@@ -88,6 +89,10 @@
 #'          that led to the error. The dump contains the workspace and in the variable "last.dump"
 #'          the call stack (\code{\link{sys.frames}}). This feature is very helpful for non-interactive R scripts ("batches").
 #'
+#'          Setting the parameter \code{tryCatchLog.write.error.dump.folder} to a specific path allows to save the dump in a specific folder. 
+#           If the path does not exist, the folder will be created using the recursive \code{dir.create()} function.
+#'          If not set, the dump will be saved in the working directory. 
+#'          
 #'          To start a post-mortem analysis after an error open a new R session and enter:
 #'             \code{load("dump_20161016_164050.rda")   # replace the dump file name with your real file name
 #'             debugger(last.dump)}
@@ -132,6 +137,7 @@ tryCatchLog <- function(expr,
                         ...,
                         finally = NULL,
                         write.error.dump.file = getOption("tryCatchLog.write.error.dump.file", FALSE),
+                        write.error.dump.folder = getOption("tryCatchLog.write.error.dump.folder", '.'),
                         silent.warnings = getOption("tryCatchLog.silent.warnings", FALSE),
                         silent.messages = getOption("tryCatchLog.silent.messages", FALSE)
                        )
@@ -166,9 +172,9 @@ tryCatchLog <- function(expr,
       # An enhanced version of "dump.frames" was released in spring 2017 but does still not fulfill the requirements of tryCatchLog:
       # dump.frames(dumpto = dump.file.name, to.file = TRUE, include.GlobalEnv = TRUE)  # test it yourself!
       dump.file.name <- format(timestamp, format = "dump_%Y%m%d_%H%M%S.rda")   # use %OS3 (= seconds incl. milliseconds) for finer precision
+      dir.create(path <- write.error.dump.folder, recursive = T, showWarnings = F)
       utils::dump.frames()
-      save.image(file = dump.file.name)
-
+      save.image(file = file.path(write.error.dump.folder, dump.file.name))
     }
 
 

--- a/R/tryLog.R
+++ b/R/tryLog.R
@@ -43,11 +43,13 @@
 #' @export
 tryLog <- function(expr,
                    write.error.dump.file = getOption("tryCatchLog.write.error.dump.file", FALSE),
+                   write.error.dump.folder = getOption("tryCatchLog.write.error.dump.folder", '.'),
                    silent.warnings = getOption("tryCatchLog.silent.warnings", FALSE),
                    silent.messages = getOption("tryCatchLog.silent.messages", FALSE))
 {
   tryCatchLog(expr = expr,
               write.error.dump.file = write.error.dump.file,
+              write.error.dump.folder = write.error.dump.folder,
               error = function(e) {
                 msg <- conditionMessage(e)
                 invisible(structure(msg, class = "try-error", condition = e))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -94,6 +94,7 @@
   op <- options()
   op.devtools <- list(
     tryCatchLog.write.error.dump.file = FALSE,
+    tryCatchLog.write.error.folder = '.',
     tryCatchLog.silent.warnings     = FALSE,
     tryCatchLog.silent.messages     = FALSE
   )

--- a/man/tryCatchLog.Rd
+++ b/man/tryCatchLog.Rd
@@ -23,7 +23,7 @@ All condition handlers are passed to \code{\link{tryCatch}} as is
 
 \item{write.error.dump.file}{\code{TRUE}: Saves a dump of the workspace and the call stack named \code{dump_<YYYYMMDD_HHMMSS>.rda}}
 
-\item{write.error.dump.folder}{\code{path}: Saves the dump of the workspace in the specific \code{path} instead of the working directory
+\item{write.error.dump.folder}{\code{path}: Saves the dump of the workspace in the specific \code{path} instead of the working directory}
 
 \item{silent.warnings}{\code{TRUE}: Warnings are logged, but not propagated to the caller.\cr
 \code{FALSE}: Warnings are logged and treated according to the global

--- a/man/tryCatchLog.Rd
+++ b/man/tryCatchLog.Rd
@@ -5,10 +5,10 @@
 \title{Try an expression with condition logging and error handling}
 \usage{
 tryCatchLog(expr, ..., finally = NULL,
-  write.error.dump.file = getOption("tryCatchLog.write.error.dump.file",
-  FALSE), silent.warnings = getOption("tryCatchLog.silent.warnings", FALSE),
-  silent.messages = getOption("tryCatchLog.silent.messages", FALSE), 
-  write.error.dump.folder = getOption("tryCatchLog.write.error.dump.folder", NULL))
+  write.error.dump.file = getOption("tryCatchLog.write.error.dump.file", FALSE),
+  write.error.dump.folder = getOption("tryCatchLog.write.error.dump.folder", '.'),
+  silent.warnings = getOption("tryCatchLog.silent.warnings", FALSE),
+  silent.messages = getOption("tryCatchLog.silent.messages", FALSE))
 }
 \arguments{
 \item{expr}{expression to be evaluated}

--- a/man/tryCatchLog.Rd
+++ b/man/tryCatchLog.Rd
@@ -7,7 +7,8 @@
 tryCatchLog(expr, ..., finally = NULL,
   write.error.dump.file = getOption("tryCatchLog.write.error.dump.file",
   FALSE), silent.warnings = getOption("tryCatchLog.silent.warnings", FALSE),
-  silent.messages = getOption("tryCatchLog.silent.messages", FALSE))
+  silent.messages = getOption("tryCatchLog.silent.messages", FALSE), 
+  write.error.dump.folder = getOption("tryCatchLog.write.error.dump.folder", NULL))
 }
 \arguments{
 \item{expr}{expression to be evaluated}
@@ -21,6 +22,8 @@ All condition handlers are passed to \code{\link{tryCatch}} as is
 \item{finally}{expression to be evaluated at the end}
 
 \item{write.error.dump.file}{\code{TRUE}: Saves a dump of the workspace and the call stack named \code{dump_<YYYYMMDD_HHMMSS>.rda}}
+
+\item{write.error.dump.folder}{\code{path}: Saves the dump of the workspace in the specific \code{path} instead of the working directory
 
 \item{silent.warnings}{\code{TRUE}: Warnings are logged, but not propagated to the caller.\cr
 \code{FALSE}: Warnings are logged and treated according to the global
@@ -86,6 +89,10 @@ This function shall overcome some drawbacks of the standard \code{\link{tryCatch
          Setting the parameter \code{tryCatchLog.write.error.dump.file} to TRUE allows a post-mortem analysis of the program state
          that led to the error. The dump contains the workspace and in the variable "last.dump"
          the call stack (\code{\link{sys.frames}}). This feature is very helpful for non-interactive R scripts ("batches").
+
+         Setting the parameter \code{tryCatchLog.write.error.dump.folder} to a specific path allows to save the dump in a specific folder. 
+         If the path does not exist, the folder will be created using the recursive \code{dir.create()} function.
+         If not set, the dump will be saved in the working directory. 
 
          To start a post-mortem analysis after an error open a new R session and enter:
             \code{load("dump_20161016_164050.rda")   # replace the dump file name with your real file name

--- a/man/tryLog.Rd
+++ b/man/tryLog.Rd
@@ -5,8 +5,9 @@
 \title{Try an expression with condition logging and error recovery}
 \usage{
 tryLog(expr,
-  write.error.dump.file = getOption("tryCatchLog.write.error.dump.file",
-  FALSE), silent.warnings = getOption("tryCatchLog.silent.warnings", FALSE),
+  write.error.dump.file = getOption("tryCatchLog.write.error.dump.file", FALSE), 
+  write.error.dump.folder = getOption("tryCatchLog.write.error.dump.folder", '.'),
+  silent.warnings = getOption("tryCatchLog.silent.warnings", FALSE),
   silent.messages = getOption("tryCatchLog.silent.messages", FALSE))
 }
 \arguments{

--- a/man/tryLog.Rd
+++ b/man/tryLog.Rd
@@ -15,6 +15,8 @@ tryLog(expr,
 
 \item{write.error.dump.file}{\code{TRUE}: Saves a dump of the workspace and the call stack named \code{dump_<YYYYMMDD_HHMMSS>.rda}}
 
+\item{write.error.dump.folder}{\code{path}: Saves the dump of the workspace in the specific \code{path} instead of the working directory}
+
 \item{silent.warnings}{\code{TRUE}: Warnings are logged, but not propagated to the caller.\cr
 \code{FALSE}: Warnings are logged and treated according to the global
 setting in \code{\link{getOption}("warn")}. See also \code{\link{warning}}.}

--- a/tests/testthat/test_append_to_last_tryCatchLog_result.R
+++ b/tests/testthat/test_append_to_last_tryCatchLog_result.R
@@ -9,6 +9,7 @@ context("test_append_to_last_tryCatchLog_result.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings"     = FALSE)
 options("tryCatchLog.silent.messages"     = FALSE)
 

--- a/tests/testthat/test_build_log_entry.R
+++ b/tests/testthat/test_build_log_entry.R
@@ -11,6 +11,7 @@ context("test_build_log_entry.R")
 options("tryCatchLog.write.error.dump.file" = FALSE)
 options("tryCatchLog.silent.warnings"       = FALSE)
 options("tryCatchLog.silent.messages"       = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 
 options("width" = 1000)  # default is 129
 

--- a/tests/testthat/test_build_log_output.R
+++ b/tests/testthat/test_build_log_output.R
@@ -9,6 +9,7 @@ context("test_build_log_output.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings"     = FALSE)
 options("tryCatchLog.silent.messages"     = FALSE)
 

--- a/tests/testthat/test_dump_files.R
+++ b/tests/testthat/test_dump_files.R
@@ -14,6 +14,7 @@ context("test_dump_files.R")
 
 
 options("tryCatchLog.write.error.dump.file" = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings" = FALSE)
 options("tryCatchLog.silent.messages" = FALSE)
 
@@ -22,8 +23,8 @@ options("tryCatchLog.silent.messages" = FALSE)
 
 # helper function to delete all existing dump files in the working directory
 # (used for test set-up)
-clean.up.dump.files <- function() {
-  existing.dump.files <- list.files(pattern = "dump_.*\\.rda")
+clean.up.dump.files <- function(path = '.') {
+  existing.dump.files <- list.files(path = path, pattern = "dump_.*\\.rda", full.names = T)
 
   if (length(existing.dump.files) > 0)
     file.remove(existing.dump.files)
@@ -32,8 +33,8 @@ clean.up.dump.files <- function() {
 
 
 # helper function to count the number of existing dump files
-number.of.dump.files <- function() {
-  dump.files <- list.files(pattern = "dump_.*\\.rda")
+number.of.dump.files <- function(path = '.') {
+  dump.files <- list.files(path = path, pattern = "dump_.*\\.rda")
   return(length(dump.files))
 }
 
@@ -61,7 +62,7 @@ test_that("no dump file is created without an error", {
 
 
 
-test_that("no dump file is created for an warning", {
+test_that("no dump file is created for a warning", {
   expect_warning(tryCatchLog(log(-1), write.error.dump.file = TRUE))
   expect_equal(number.of.dump.files(), 0)
   clean.up.dump.files()
@@ -183,4 +184,21 @@ test_that("dump file is created (error and dump default enabled)", {
 
 
 
+options("tryCatchLog.write.error.dump.folder" = 'temp_subfolder')
+test_that("dump file is created in a specifc (error and dump default enabled)", {
+  tryCatchLog(
+    log("a"),
+    error = function(e) {
+    }
+  )
+  expect_equal(number.of.dump.files('temp_subfolder'), 1)
+  clean.up.dump.files('temp_subfolder')
+})
+
+
+#Cleanup
 clean.up.dump.files()
+clean.up.dump.files('temp_subfolder')
+unlink("temp_subfolder")
+
+options("tryCatchLog.write.error.dump.file" = '.')

--- a/tests/testthat/test_is_duplicated_log_entry.R
+++ b/tests/testthat/test_is_duplicated_log_entry.R
@@ -8,6 +8,7 @@ context("test_is_duplicated_log_entry.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings"     = FALSE)
 options("tryCatchLog.silent.messages"     = FALSE)
 

--- a/tests/testthat/test_is_windows.R
+++ b/tests/testthat/test_is_windows.R
@@ -8,6 +8,7 @@ context("test_is_windows.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings"     = FALSE)
 options("tryCatchLog.silent.messages"     = FALSE)
 

--- a/tests/testthat/test_issue_0017_value_3L_unused_arg.R
+++ b/tests/testthat/test_issue_0017_value_3L_unused_arg.R
@@ -12,6 +12,7 @@ context("test_issue_0017_value_3L_unused_arg.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)    # global default setting for all tryCatchLog call params "write.error.dump.file"
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings" = FALSE)
 options("tryCatchLog.silent.messages" = FALSE)
 

--- a/tests/testthat/test_last_tryCatchLog_result.R
+++ b/tests/testthat/test_last_tryCatchLog_result.R
@@ -9,6 +9,7 @@ context("test_last_tryCatchLog_result.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings"     = FALSE)
 options("tryCatchLog.silent.messages"     = FALSE)
 

--- a/tests/testthat/test_limited_Labels_Compact.R
+++ b/tests/testthat/test_limited_Labels_Compact.R
@@ -9,6 +9,7 @@ context("test_limited_Labels_Compact.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings"     = FALSE)
 options("tryCatchLog.silent.messages"     = FALSE)
 

--- a/tests/testthat/test_load_package.R
+++ b/tests/testthat/test_load_package.R
@@ -30,12 +30,14 @@ test_that("non-existing options are initialized when package is loaded", {
 
   # Unset the options
   options("tryCatchLog.write.error.dump.file" = NULL)
+  options("tryCatchLog.write.error.dump.folder" = ".")
   options("tryCatchLog.silent.warnings"       = NULL)
   options("tryCatchLog.silent.messages"       = NULL)
 
 
 
   expect_null(getOption("tryCatchLog.write.error.dump.file"))
+  expect_equal(getOption("tryCatchLog.write.error.dump.folder"), ".")
   expect_null(getOption("tryCatchLog.silent.warnings"))
   expect_null(getOption("tryCatchLog.silent.messages"))
 
@@ -46,6 +48,7 @@ test_that("non-existing options are initialized when package is loaded", {
 
   # tryCatchLog initializes all non-existing options to FALSE
   expect_false(getOption("tryCatchLog.write.error.dump.file"))
+  expect_equal(getOption("tryCatchLog.write.error.dump.folder"), ".")
   expect_false(getOption("tryCatchLog.silent.warnings"))
   expect_false(getOption("tryCatchLog.silent.messages"))
 
@@ -69,12 +72,14 @@ test_that("existing options are left untouched when package is loaded", {
 
   # Preset the options
   options("tryCatchLog.write.error.dump.file" = TRUE)
+  options("tryCatchLog.write.error.dump.folder" = ".")
   options("tryCatchLog.silent.warnings"       = TRUE)
   options("tryCatchLog.silent.messages"       = TRUE)
 
 
 
   expect_true(getOption("tryCatchLog.write.error.dump.file"))
+  expect_equal(getOption("tryCatchLog.write.error.dump.folder"), ".")
   expect_true(getOption("tryCatchLog.silent.warnings"))
   expect_true(getOption("tryCatchLog.silent.messages"))
 
@@ -84,6 +89,7 @@ test_that("existing options are left untouched when package is loaded", {
 
 
   expect_true(getOption("tryCatchLog.write.error.dump.file"))
+  expect_equal(getOption("tryCatchLog.write.error.dump.folder"), ".")
   expect_true(getOption("tryCatchLog.silent.warnings"))
   expect_true(getOption("tryCatchLog.silent.messages"))
 

--- a/tests/testthat/test_namespace_hooks.R
+++ b/tests/testthat/test_namespace_hooks.R
@@ -77,10 +77,12 @@ test_that("non-existing options are initialized when package is loaded", {
 
   # Unset the options
   options("tryCatchLog.write.error.dump.file" = NULL)
+  options("tryCatchLog.write.error.dump.folder" = ".")
   options("tryCatchLog.silent.warnings"       = NULL)
   options("tryCatchLog.silent.messages"       = NULL)
 
   expect_null(getOption("tryCatchLog.write.error.dump.file"))
+  expect_equal(getOption("tryCatchLog.write.error.dump.folder"), ".")
   expect_null(getOption("tryCatchLog.silent.warnings"))
   expect_null(getOption("tryCatchLog.silent.messages"))
 
@@ -95,6 +97,7 @@ test_that("non-existing options are initialized when package is loaded", {
 
   # tryCatchLog initializes all non-existing options to FALSE
   expect_false(getOption("tryCatchLog.write.error.dump.file"))
+  expect_equal(getOption("tryCatchLog.write.error.dump.folder"), ".")
   expect_false(getOption("tryCatchLog.silent.warnings"))
   expect_false(getOption("tryCatchLog.silent.messages"))
 
@@ -108,12 +111,14 @@ test_that("existing options are left untouched when package is loaded", {
 
   # Preset the options
   options("tryCatchLog.write.error.dump.file" = TRUE)
+  options("tryCatchLog.write.error.dump.folder" = ".")
   options("tryCatchLog.silent.warnings"       = TRUE)
   options("tryCatchLog.silent.messages"       = TRUE)
 
 
 
   expect_true(getOption("tryCatchLog.write.error.dump.file"))
+  expect_equal(getOption("tryCatchLog.write.error.dump.folder"), ".")
   expect_true(getOption("tryCatchLog.silent.warnings"))
   expect_true(getOption("tryCatchLog.silent.messages"))
 
@@ -127,6 +132,7 @@ test_that("existing options are left untouched when package is loaded", {
 
 
   expect_true(getOption("tryCatchLog.write.error.dump.file"))
+  expect_equal(getOption("tryCatchLog.write.error.dump.folder"), ".")
   expect_true(getOption("tryCatchLog.silent.warnings"))
   expect_true(getOption("tryCatchLog.silent.messages"))
 

--- a/tests/testthat/test_silent_messages.R
+++ b/tests/testthat/test_silent_messages.R
@@ -13,6 +13,7 @@ context("test_silent_messages.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings"     = FALSE)
 options("tryCatchLog.silent.messages"     = FALSE)
 

--- a/tests/testthat/test_silent_stacked_warnings.R
+++ b/tests/testthat/test_silent_stacked_warnings.R
@@ -9,6 +9,7 @@ context("test_silent_stacked_warnings.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings"     = FALSE)
 options("tryCatchLog.silent.messages"     = FALSE)
 

--- a/tests/testthat/test_silent_warnings.R
+++ b/tests/testthat/test_silent_warnings.R
@@ -13,6 +13,7 @@ context("test_silent_warnings.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)    # global default setting for all tryCatchLog call params "write.error.dump.file"
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings" = FALSE)
 options("tryCatchLog.silent.messages" = FALSE)
 
@@ -86,6 +87,7 @@ test_that("tryCatchLog did throw an error", {
 
 # clean-up test setup ---------------------------------------------------------------------------------------------
 options("tryCatchLog.write.error.dump.file" = FALSE)    # global default setting for all tryCatchLog call params "write.error.dump.file"
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings" = FALSE)
 options("tryCatchLog.silent.messages" = FALSE)
 

--- a/tests/testthat/test_stacked_tryCatchLog.R
+++ b/tests/testthat/test_stacked_tryCatchLog.R
@@ -9,6 +9,7 @@ context("test_stacked_tryCatchLog.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings"     = FALSE)
 options("tryCatchLog.silent.messages"     = FALSE)
 

--- a/tests/testthat/test_tryCatchLog_basics.R
+++ b/tests/testthat/test_tryCatchLog_basics.R
@@ -11,6 +11,7 @@ context("test_tryCatchLog_basics.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)    # global default setting for all tryCatchLog call params "write.error.dump.file"
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings"       = FALSE)
 options("tryCatchLog.silent.messages"       = FALSE)
 

--- a/tests/testthat/test_tryCatch_semantics.R
+++ b/tests/testthat/test_tryCatch_semantics.R
@@ -20,6 +20,7 @@ on.exit(options(error = saved.options))
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)    # global default setting for all tryCatchLog call params "write.error.dump.file"
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings" = FALSE)
 options("tryCatchLog.silent.messages" = FALSE)
 

--- a/tests/testthat/test_tryLog_basics.R
+++ b/tests/testthat/test_tryLog_basics.R
@@ -11,6 +11,7 @@ context("test_tryLog_basics.R")
 
 # set up test context
 options("tryCatchLog.write.error.dump.file" = FALSE)    # global default setting for all tryCatchLog call params "write.error.dump.file"
+options("tryCatchLog.write.error.dump.folder" = ".")
 options("tryCatchLog.silent.warnings" = FALSE)
 options("tryCatchLog.silent.messages" = FALSE)
 


### PR DESCRIPTION
My "working directory" is read-only in production.
This option can be set to write the dump in a specidic output folder: options("tryCatchLog.write.error.dump.folder" = ".")