### PR TITLE
WIP: Example code for issue_052

### DIFF
--- a/R/build_log_entry.R
+++ b/R/build_log_entry.R
@@ -24,6 +24,7 @@
 #' @param timestamp       logging timestamp as \code{\link{POSIXct}} (normally by calling \code{\link{Sys.time}})
 #' @param severity        severity level of the log entry ((ERROR, WARN, INFO etc.)
 #' @param msg.text        Logging message (e. g. error message)
+#' @param pid             a process id or other text identifier that will be added to msg.text
 #' @param call.stack      a call stack created by \code{\link{sys.calls}}
 #' @param dump.file.name  name of the created dump file (leave empty if the \code{\link{tryCatchLog}}
 #'                        argument \code{write.error.dump.file} is \code{FALSE}
@@ -47,7 +48,7 @@
 #'               \code{\link{build.log.output}}
 #'
 #' @note         THIS IS A PACKAGE INTERNAL FUNCTION AND THEREFORE NOT EXPORTED.
-build.log.entry <- function(timestamp, severity, msg.text, call.stack, dump.file.name, omit.call.stack.items = 0) {
+build.log.entry <- function(timestamp, severity, msg.text, pid, call.stack, dump.file.name, omit.call.stack.items = 0) {
 
   stopifnot(inherits(timestamp, "POSIXct"))
 
@@ -56,6 +57,7 @@ build.log.entry <- function(timestamp, severity, msg.text, call.stack, dump.file
   log.entry <- data.frame(timestamp           = timestamp,
                           severity            = severity,
                           msg.text            = msg.text,
+                          pid                 = ifelse(is.null(pid), NA, pid),
                           compact.stack.trace = get.pretty.call.stack(call.stack, omit.call.stack.items, compact = TRUE),
                           full.stack.trace    = get.pretty.call.stack(call.stack, omit.call.stack.items),
                           dump.file.name      = dump.file.name,

--- a/R/build_log_output.R
+++ b/R/build_log_output.R
@@ -82,6 +82,8 @@ build.log.output <- function(log.results,
                   if (include.severity)
                     paste0("[", log.results$severity[i], "] "),
                   log.results$msg.text[i],
+                  if (!is.na(log.results$pid[i]))
+                    " ", log.results$pid[i], # No condition required, won't show if NULL
                   "\n\n",
                   if (nchar(log.results$dump.file.name[i]) > 0)
                     paste0("Created dump file: ", log.results$dump.file.name[i], "\n\n"),

--- a/R/build_log_output.R
+++ b/R/build_log_output.R
@@ -83,7 +83,7 @@ build.log.output <- function(log.results,
                     paste0("[", log.results$severity[i], "] "),
                   log.results$msg.text[i],
                   if (!is.na(log.results$pid[i]))
-                    " ", log.results$pid[i], # No condition required, won't show if NULL
+                    paste0(" ", log.results$pid[i]), # No condition required, won't show if NULL
                   "\n\n",
                   if (nchar(log.results$dump.file.name[i]) > 0)
                     paste0("Created dump file: ", log.results$dump.file.name[i], "\n\n"),

--- a/R/tryCatchLog.R
+++ b/R/tryCatchLog.R
@@ -32,6 +32,7 @@
 #'                              \code{error}, \code{warning}, \code{message} and \code{interrupt}.
 #'                              All condition handlers are passed to \code{\link{tryCatch}} as is
 #'                              (no filtering, wrapping or changing of semantics).
+#' @param pid                   a process id or other text identifier that will be added to msg.text
 #' @param finally               expression to be evaluated at the end
 #' @param write.error.dump.file \code{TRUE}: Saves a dump of the workspace and the call stack named
 #'                              \code{dump_<YYYYMMDD>_at_<HHMMSS.sss>_PID_<process id>.rda}.
@@ -146,6 +147,7 @@
 tryCatchLog <- function(expr,
                         # error = function(e) {if (!is.null(getOption("error", stop))) eval(getOption("error", stop)) }, # getOption("error", default = stop),
                         ...,
+                        pid = NULL,
                         finally = NULL,
                         write.error.dump.file      = getOption("tryCatchLog.write.error.dump.file", FALSE),
                         write.error.dump.folder    = getOption("tryCatchLog.write.error.dump.folder", "."),
@@ -197,7 +199,7 @@ tryCatchLog <- function(expr,
 
 
 
-    log.entry <- build.log.entry(timestamp, severity, log.message, call.stack, dump.file.name, omit.call.stack.items = 1)
+    log.entry <- build.log.entry(timestamp, severity, log.message, pid, call.stack, dump.file.name, omit.call.stack.items = 1)
 
     if (!is.duplicated.log.entry(log.entry)) {
 


### PR DESCRIPTION
This is what I was thinking about as an example. re: #52  

Let's say you have thousands of processes running on a cluster or even on one machine in parallel. Without being able to set some type of pid you would see the error come out perfectly but you might not be able to identify the process that spawned it. 

My use case might be pretty unique (within a big cluster running a bunch of jobs that need to be repeated over and over as new data comes in). Not sure if you would be interested in keeping these adjustments but figured I would share them all the same.  