### PR TITLE
Feature/62 optional logging of conditions

### DIFF
--- a/R/tryCatchLog.R
+++ b/R/tryCatchLog.R
@@ -66,6 +66,9 @@
 #'                     call stacks the message text will be output without call stacks.
 #'                     The default value can be changed globally by setting the option \code{tryCatchLog.include.compact.call.stack}.
 #'                     The compact call stack can always be found via \code{\link{last.tryCatchLog.result}}.
+#' @param logged.conditions \code{NULL}: Conditions are not logged.\cr
+#'                          \code{vector of strings}: Only conditions whose class name is contained in this vector are logged.\cr
+#'                          \code{NA}: All conditions are logged.
 #' @return                     the value of the expression passed in as parameter "expr"
 #'
 #' @details This function shall overcome some drawbacks of the standard \code{\link{tryCatch}} function.\cr
@@ -183,7 +186,8 @@ tryCatchLog <- function(expr,
                         silent.warnings            = getOption("tryCatchLog.silent.warnings", FALSE),
                         silent.messages            = getOption("tryCatchLog.silent.messages", FALSE),
                         include.full.call.stack    = getOption("tryCatchLog.include.full.call.stack", TRUE),
-                        include.compact.call.stack = getOption("tryCatchLog.include.compact.call.stack", TRUE)
+                        include.compact.call.stack = getOption("tryCatchLog.include.compact.call.stack", TRUE),
+                        logged.conditions          = getOption("tryCatchLog.logged.conditions", NULL)
 ) {
 
   reset.last.tryCatchLog.result()   # TODO If an internal error is thrown in the code above the last result will be kept. Fix this?
@@ -218,13 +222,21 @@ tryCatchLog <- function(expr,
     call.stack     <- sys.calls()          # "sys.calls" within "withCallingHandlers" is like a traceback!
     dump.file.name <- ""
 
-    # stack.trace <<- call.stack     # helper code for updating the expected result of the "test_build_log_entry" unit test
 
+    # stack.trace <<- call.stack     # helper code for updating the expected result of the "test_build_log_entry" unit test
     severity <-       if (inherits(c, "error"))     "ERROR"
                  else if (inherits(c, "warning"))   "WARN"
                  else if (inherits(c, "message"))   "INFO"
                  else if (inherits(c, "interrupt")) "INFO"
-                 else if (inherits(c, "condition")) "INFO"
+                 else if (inherits(c, "condition")) {
+                   # if logged.conditions is NULL (default), do not log conditions
+                   if (is.null(logged.conditions))     return()
+                   # if logged.conditions is NA, log all conditions
+                   else if ((length(logged.conditions) == 1) && is.na(logged.conditions))   "INFO"
+                   # if logged.conditions is a vector of strings, log only conditions which have their class in the vector
+                   else if (inherits(c, logged.conditions))   "INFO"
+                   else if (!inherits(c, logged.conditions))   return()
+                 }
                  else stop(sprintf("Unsupported condition class %s!", class(c)))
 
 

--- a/R/tryLog.R
+++ b/R/tryLog.R
@@ -49,6 +49,7 @@ tryLog <- function(expr,
                    silent.messages            = getOption("tryCatchLog.silent.messages", FALSE),
                    include.full.call.stack    = getOption("tryCatchLog.include.full.call.stack", TRUE),
                    include.compact.call.stack = getOption("tryCatchLog.include.compact.call.stack", TRUE),
+                   logged.conditions          = getOption("tryCatchLog.logged.conditions", NULL),
                    execution.context.msg      = ""
 ) {
 
@@ -63,5 +64,6 @@ tryLog <- function(expr,
               silent.warnings            = silent.warnings,
               silent.messages            = silent.messages,
               include.full.call.stack    = include.full.call.stack,
-              include.compact.call.stack = include.compact.call.stack)
+              include.compact.call.stack = include.compact.call.stack,
+              logged.conditions = logged.conditions)
 }

--- a/man/tryCatchLog.Rd
+++ b/man/tryCatchLog.Rd
@@ -15,7 +15,8 @@ tryCatchLog(
   silent.messages = getOption("tryCatchLog.silent.messages", FALSE),
   include.full.call.stack = getOption("tryCatchLog.include.full.call.stack", TRUE),
   include.compact.call.stack = getOption("tryCatchLog.include.compact.call.stack",
-    TRUE)
+    TRUE),
+  logged.conditions = getOption("tryCatchLog.logged.conditions", NULL)
 )
 }
 \arguments{
@@ -65,6 +66,10 @@ be included in the log output? Note: If you ommit both the full and compact
 call stacks the message text will be output without call stacks.
 The default value can be changed globally by setting the option \code{tryCatchLog.include.compact.call.stack}.
 The compact call stack can always be found via \code{\link{last.tryCatchLog.result}}.}
+
+\item{logged.conditions}{\code{NULL}: Conditions are not logged.\cr
+\code{vector of strings}: Only conditions whose class name is contained in this vector are logged.\cr
+\code{NA}: All conditions are logged.}
 }
 \value{
 the value of the expression passed in as parameter "expr"

--- a/man/tryLog.Rd
+++ b/man/tryLog.Rd
@@ -13,6 +13,7 @@ tryLog(
   include.full.call.stack = getOption("tryCatchLog.include.full.call.stack", TRUE),
   include.compact.call.stack = getOption("tryCatchLog.include.compact.call.stack",
     TRUE),
+  logged.conditions = getOption("tryCatchLog.logged.conditions", NULL),
   execution.context.msg = ""
 )
 }
@@ -45,6 +46,10 @@ be included in the log output? Note: If you ommit both the full and compact
 call stacks the message text will be output without call stacks.
 The default value can be changed globally by setting the option \code{tryCatchLog.include.compact.call.stack}.
 The compact call stack can always be found via \code{\link{last.tryCatchLog.result}}.}
+
+\item{logged.conditions}{\code{NULL}: Conditions are not logged.\cr
+\code{vector of strings}: Only conditions whose class name is contained in this vector are logged.\cr
+\code{NA}: All conditions are logged.}
 
 \item{execution.context.msg}{a text identifier (eg. the PID or a variable value) that will be added to msg.text
 for catched conditions. This makes it easier to identify the runtime state that caused

--- a/tests/testthat/test_logging_of_conditions.R
+++ b/tests/testthat/test_logging_of_conditions.R
@@ -1,0 +1,48 @@
+# Tests are run within the folder "tryCatchLog/tests/testthat".
+# Clean it up at the beginning of a test!
+
+library(testthat)
+
+
+
+# Silent warnings -------------------------------------------------------------------------------------------------
+
+context("test_logging_of_conditions.R")
+
+
+
+source("init_unit_test.R")
+
+
+
+# suppress logging of errors and warnings to avoid overly output
+source("disable_logging_output.R")
+
+
+
+# Test implementations --------------------------------------------------------------------------------------------
+
+test_that("A message is displayed for any value of logged.conditions", {
+  for (logged.conditions in list(NULL, NA, c("cond1", "cond2"))) {
+    expect_message(tryCatchLog(message("hello"), logged.conditions = logged.conditions))
+    expect_message(tryLog(message("hello"), logged.conditions = logged.conditions))
+  }
+})
+
+test_that("tryCatchLog is silent when a condition is thrown and logged.conditions is NULL", {
+  expect_silent(tryCatchLog(rlang::signal("condition 1", class = "cond1"), logged.conditions = NULL))
+})
+
+test_that("tryCatchLog logs a condition when a condition is thrown and logged.conditions is NA", {
+  expect_condition(tryCatchLog(rlang::signal("condition 1", class = "cond1"), logged.conditions = NA))
+})
+
+test_that("tryCatchLog logs a condition when a condition which class is in logged.conditions is thrown", {
+  expect_condition(tryCatchLog(rlang::signal("condition 1", class = "cond1"), logged.conditions = c("cond1", "cond2")))
+})
+
+test_that("tryCatchLog is silent when a condition which class is NOT in logged.conditions is thrown", {
+  expect_silent(tryCatchLog(rlang::signal("condition 3", class = "cond3"), logged.conditions = c("cond1", "cond2")))
+})
+
+


### PR DESCRIPTION
I chose to have the default (no logging of conditions) `logged.conditions` to `NULL` instead of `""` so as to keep consistency with an empty string vector `c() `. Let me know what you think. Cheers.