### PR TITLE
allow {lgr} as logger

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Encoding: UTF-8
 RoxygenNote: 7.1.1
 Suggests:
     futile.logger,
+    lgr,
     testthat,
     knitr,
     rmarkdown,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -75,6 +75,8 @@
   # Indicate which logging functions to use
   if (.tryCatchLog.env$found.futile.logger == TRUE) {             # is.package.available("futile.logger")) {
     packageStartupMessage("Using futile.logger for logging...")
+  }else if (.tryCatchLog.env$found.lgr == TRUE) {             # is.package.available("futile.logger")) {
+    packageStartupMessage("Using lgr for logging...")
   } else {
     packageStartupMessage("futile.logger not found. Using tryCatchLog-internal functions for logging...")
   }
@@ -121,13 +123,27 @@
 
 
   # Decide which logging functions to use
+  
   if (is.package.available("futile.logger")) {
     # packageStartupMessage("Using futile.logger for logging...")  # be silent in .onLoad (best practice)
     set.logging.functions(futile.logger::flog.error, futile.logger::flog.warn, futile.logger::flog.info)
+    .tryCatchLog.env$found.lgr <- FALSE
     .tryCatchLog.env$found.futile.logger <- TRUE
+  }else if (is.package.available("lgr")) {
+    if( ! exists("lg", envir = parent.env(environment()))){
+      assign(
+        "lg",
+        lgr::get_logger(name = "tryCatchLog"),
+        envir = parent.env(environment())
+      )
+    }
+    set.logging.functions(lg$error, lg$warn, lg$info)
+    .tryCatchLog.env$found.lgr <- TRUE
+    .tryCatchLog.env$found.futile.logger <- FALSE
   } else {
     # packageStartupMessage("futile.logger not found. Using tryCatchLog-internal functions for logging...")  # be silent in .onLoad (best practice)
     set.logging.functions()    # Default: Activate the package-internal minimal logging functions
+    .tryCatchLog.env$found.lgr <- FALSE
     .tryCatchLog.env$found.futile.logger <- FALSE
   }
 

--- a/tests/testthat/test_namespace_hooks.R
+++ b/tests/testthat/test_namespace_hooks.R
@@ -77,6 +77,18 @@ test_that("futile.logger is used if it is installed", {
 
 })
 
+test_that("lgr is used if it is installed", {
+
+  skip_if_not_installed("lgr")
+
+#  with_mock(
+#    `tryCatchLog:::is.package.available` = function(pkg.name) return(TRUE),
+    # expect_silent(tryCatchLog:::.onAttach(".", "tryCatchLog"))
+    expect_message(tryCatchLog:::.onAttach(".", "tryCatchLog"), "Using lgr for logging")
+#  )
+
+})
+
 
 
 test_that("non-existing options are initialized when package is loaded", {


### PR DESCRIPTION
Hello,
I was wondering whether it would be possible to allow {lgr} as logger instead of {futile.logger}.
I gave it a try and it seems to work, the tests run fine but I don't know all the inner details of the package and I can't figure out unintended consequences.
Please give it a thought.

Nice package anyway, pretty useful.

Best, 
Duccio